### PR TITLE
fix: out-by-one indexing error

### DIFF
--- a/Demo/2017/TypeRepositoryBenchmarks/Utf8SearchBenchmark/BoyerMoore.cs
+++ b/Demo/2017/TypeRepositoryBenchmarks/Utf8SearchBenchmark/BoyerMoore.cs
@@ -43,7 +43,7 @@ unsafe static class BoyerMoore
     {
         int lastPrefixIndex = 1;
 
-        for (var p = patternLength; p > 0; p--)
+        for (var p = patternLength - 1; p >= 0; p--)
         {
             if (IsPrefix(pattern, patternLength, p)) lastPrefixIndex = p;
             delta2[p] = (patternLength - p) + lastPrefixIndex;


### PR DESCRIPTION
Found bug while refactoring to use `Span` instead of pointers. Also see the C reference [code](https://github.com/likejazz/boyer-moore-string-search/blob/master/boyer-moore.c#L123)